### PR TITLE
Fix `<details><summary>` content formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 
 <details>
 <summary><b>In Firefox</b></summary>
+
 1. Go to `about:debugging#/runtime/this-firefox`
 2. Click "Load Temporary Addon"
 3. Select `manifest.json` in the downloaded folder
@@ -34,6 +35,7 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 
 <details>
 <summary><b>In Chrome/Chromium browsers</b></summary>
+
 1. Go to `chrome://extensions`
 2. Enable "Developer Mode" in the top right
 3. Click "Load Unpacked"
@@ -46,6 +48,7 @@ Simply prefix this code with `javascript:` and save it as a bookmark on Chrome o
 
 <details>
 <summary><b>In Microsoft Edge</b></summary>
+
 1. Go to `edge://extensions`
 2. Click "Load Unpacked"
 3. Select the downloaded folder. Please use the Chrome version of the extension.


### PR DESCRIPTION
### Description

This PR is a small fix for the `<details><summary>` content formatting in README.

#### Before

In https://github.com/OrionReed/dom3d _main_ branch:

<img width="864" alt="Screenshot 2024-03-31 at 13 30 36" src="https://github.com/julien-deramond/dom3d/assets/17381666/81512b3b-311f-4f44-9484-1966fe6f2ddf">

#### Now

See https://github.com/julien-deramond/dom3d/blob/84e51af8036bfb79f859b26a2bce11cb43db99c8/README.md

<img width="951" alt="Screenshot 2024-03-31 at 13 37 51" src="https://github.com/julien-deramond/dom3d/assets/17381666/6de8adad-ed5f-48a2-95aa-8e9b2900f890">
